### PR TITLE
Support jsonb type

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-postgresql "0.4.0"
+(defproject clj-postgresql "0.5.0"
   :description "PostgreSQL helpers for Clojure projects"
   :url "https://github.com/remodoy/clj-postgresql"
   :license {:name "Two clause BSD license"

--- a/project.clj
+++ b/project.clj
@@ -5,16 +5,16 @@
             :url "http://github.com/remodoy/clj-postgresql/README.md"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [postgresql "9.3-1102.jdbc41"]
-                 [cheshire "5.3.1"]
+                 [cheshire "5.4.0"]
                  [com.jolbox/bonecp "0.8.0.RELEASE"]
-                 [clj-time "0.8.0"]
+                 [clj-time "0.9.0"]
                  [org.clojure/java.data "0.1.1"]
-                 [org.clojure/java.jdbc "0.3.5"]
-                 [org.slf4j/slf4j-api "1.7.7"]
+                 [org.clojure/java.jdbc "0.3.6"]
+                 [org.slf4j/slf4j-api "1.7.9"]
                  [org.postgis/postgis-jdbc "1.3.3"]
                  [com.taoensso/timbre "3.3.1" :exclusions [org.clojure/clojure]]
-                 [prismatic/schema "0.2.6"]]
+                 [prismatic/schema "0.3.3"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]
-                                  [org.slf4j/slf4j-simple "1.7.7"]]
+                                  [org.slf4j/slf4j-simple "1.7.9"]]
                    :plugins [[lein-midje "3.1.1"]]}})
 

--- a/src/clj_postgresql/core.clj
+++ b/src/clj_postgresql/core.clj
@@ -33,12 +33,18 @@ PostgreSQL environment variables PGDATABASE, PGHOST, PGPORT, PGUSER and by readi
 
 (defn default-spec
   "Reasonable defaults as with the psql command line tool.
-   Use username for user and db. Don't use host."
+  Use username for user and db. Don't use host."
   []
-  (let [username (java.lang.System/getProperty "user.name")]
-    {:dbtype "postgresql"
-     :user username
-     :dbname username}))
+  (let [username (or (System/getenv "PGUSER")
+                     (java.lang.System/getProperty "user.name"))]
+    (conj
+      {:dbtype "postgresql"
+       :user username
+       :dbname username}
+      (when-let [password (System/getenv "PGPASSWORD")]
+        {:password password})
+      (when-let [dbname (System/getenv "PGDATABASE")]
+        {:dbname dbname}))))
 
 (defn env-spec
   "Get db spec by reading PG* variables from the environment."

--- a/src/clj_postgresql/types.clj
+++ b/src/clj_postgresql/types.clj
@@ -89,11 +89,19 @@
   [m _]
   (jdbc/sql-value (coerce/geojson->postgis m)))
 
+(defn- to-pg-json [data json-type]
+  (doto (PGobject.)
+    (.setType (name json-type))
+    (.setValue (json/generate-string data))))
+
 (defmethod map->parameter :json
   [m _]
-  (doto (PGobject.)
-    (.setType "json")
-    (.setValue (json/generate-string m))))
+  (to-pg-json m :json))
+
+(defmethod map->parameter :jsonb
+  [m _]
+  (to-pg-json m :jsonb))
+
               
 (extend-protocol jdbc/ISQLParameter
   clojure.lang.IPersistentMap
@@ -224,6 +232,13 @@
   [^org.postgresql.util.PGobject x]
   (when-let [val (.getValue x)]
     (json/parse-string val)))
+
+(defmethod read-pgobject :jsonb
+  [^org.postgresql.util.PGobject x]
+  (when-let [val (.getValue x)]
+    (json/parse-string val)))
+
+
 
 (defmethod read-pgobject :default
   [^org.postgresql.util.PGobject x]

--- a/test/clj_postgresql/t_types.clj
+++ b/test/clj_postgresql/t_types.clj
@@ -1,0 +1,20 @@
+(ns clj-postgresql.t-types
+  (:use midje.sweet)
+  (:require [clj-postgresql.core :as pg]
+            [clj-postgresql.types]
+            [clojure.java.jdbc :as jdbc]))
+
+(def test-data
+  {"x" 42 "a" [4 3 2]})
+
+(facts "wirte and read json and jsonb"
+       (jdbc/with-db-transaction [tx (pg/spec)]
+         (jdbc/db-do-commands tx "CREATE TEMP TABLE test (json_field json, jsonb_field jsonb)")
+         (fact (first (jdbc/insert! tx :test {:jsonb_field test-data :json_field test-data}))
+               => {:jsonb_field test-data :json_field test-data})
+         (let [row  (first (jdbc/query tx "SELECT * FROM test"))]
+           (fact row => truthy)
+           (fact (:json_field row) => test-data)
+           (fact (:jsonb_field row) => test-data)
+           )))
+


### PR DESCRIPTION
* support jsonb type (available as of postgres 9.4); also add some tests for this case, they will break when run on 9.3 or earlier, but the code itself is backwards compatible 
* use PGUSER, PGDATABASE, and PGPASSWORD when evaluating default-spec; PG evn vars will take precedence over e.g. user name property which seems reasonable to me
* set version to 0.5.0 