### PR TITLE
Switch from BoneCP to Hikari

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,10 @@
+{:deps
+ {org.clojure/clojure #:mvn{:version "1.10.0"},
+  hikari-cp #:mvn{:version "2.7.1"},
+  net.postgis/postgis-jdbc #:mvn{:version "2.3.0"},
+  clj-time #:mvn{:version "0.15.1"},
+  org.postgresql/postgresql #:mvn{:version "42.2.5"},
+  cheshire #:mvn{:version "5.8.1"},
+  org.clojure/java.jdbc #:mvn{:version "0.7.9"},
+  prismatic/schema #:mvn{:version "1.1.10"},
+  org.clojure/java.data #:mvn{:version "0.1.1"}}}

--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,15 @@
   :license {:name "Two clause BSD license"
             :url "http://github.com/remodoy/clj-postgresql/README.md"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.postgresql/postgresql "42.1.4"]
-                 [net.postgis/postgis-jdbc "2.2.1" :exclusions [postgresql org.postgresql/postgresql]]
-                 [cheshire "5.8.0"]
+                 [org.postgresql/postgresql "42.2.5"]
+                 [net.postgis/postgis-jdbc "2.3.0" :exclusions [postgresql org.postgresql/postgresql]]
+                 [cheshire "5.8.1"]
                  [com.jolbox/bonecp "0.8.0.RELEASE"]
-                 [clj-time "0.14.2"]
+                 [clj-time "0.15.1"]
                  [org.clojure/java.data "0.1.1"]
-                 [org.clojure/java.jdbc "0.7.3"]
-                 [prismatic/schema "1.1.7"]]
-  :profiles {:dev {:dependencies [[midje "1.9.0"]
-                                  [org.slf4j/slf4j-simple "1.7.25"]]
+                 [org.clojure/java.jdbc "0.7.9"]
+                 [prismatic/schema "1.1.10"]]
+  :profiles {:dev {:dependencies [[midje "1.9.8"]
+                                  [org.slf4j/slf4j-simple "1.7.26"]]
                    :plugins [[lein-midje "3.1.1"]]}})
 

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.postgresql/postgresql "42.2.5"]
                  [net.postgis/postgis-jdbc "2.3.0" :exclusions [postgresql org.postgresql/postgresql]]
+                 [hikari-cp "2.7.1"]
                  [cheshire "5.8.1"]
                  [com.jolbox/bonecp "0.8.0.RELEASE"]
                  [clj-time "0.15.1"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/remodoy/clj-postgresql"
   :license {:name "Two clause BSD license"
             :url "http://github.com/remodoy/clj-postgresql/README.md"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.postgresql/postgresql "42.2.5"]
                  [net.postgis/postgis-jdbc "2.3.0" :exclusions [postgresql org.postgresql/postgresql]]
                  [hikari-cp "2.7.1"]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
                  [net.postgis/postgis-jdbc "2.3.0" :exclusions [postgresql org.postgresql/postgresql]]
                  [hikari-cp "2.7.1"]
                  [cheshire "5.8.1"]
-                 [com.jolbox/bonecp "0.8.0.RELEASE"]
                  [clj-time "0.15.1"]
                  [org.clojure/java.data "0.1.1"]
                  [org.clojure/java.jdbc "0.7.9"]

--- a/src/clj_postgresql/pool.clj
+++ b/src/clj_postgresql/pool.clj
@@ -1,13 +1,11 @@
 (ns clj-postgresql.pool
-  "BoneCP based connection pool"
+  "Hikari based connection pool"
   (:require [clojure.java.data :as data]
             [hikari-cp.core :as hikari])
-  (:import (com.jolbox.bonecp BoneCPDataSource BoneCPConfig ConnectionHandle)
-           (com.jolbox.bonecp.hooks AbstractConnectionHook)
-           (java.util.concurrent TimeUnit)))
+  (:import (java.util.concurrent TimeUnit)))
 
 (defn db-spec->pool-config
-  "Converts a db-spec with :host :port :dbname and :user to bonecp pool config"
+  "Converts a db-spec with :host :port :dbname and :user to Hikari pool config"
   [{:keys [dbtype host port dbname user password]}]
   (let [host-part (when host (if port (format "%s:%s" host port) host))
         pool-conf {:jdbc-url (format "jdbc:%s://%s/%s" dbtype (or host-part "") dbname)
@@ -23,4 +21,4 @@
 
 (defn close-pooled-db!
   [{:keys [datasource]}]
-  (.close ^BoneCPDataSource datasource))
+  (hikari/close-datasource datasource))

--- a/src/clj_postgresql/pool.clj
+++ b/src/clj_postgresql/pool.clj
@@ -1,6 +1,7 @@
 (ns clj-postgresql.pool
   "BoneCP based connection pool"
-  (:require [clojure.java.data :as data])
+  (:require [clojure.java.data :as data]
+            [hikari-cp.core :as hikari])
   (:import (com.jolbox.bonecp BoneCPDataSource BoneCPConfig ConnectionHandle)
            (com.jolbox.bonecp.hooks AbstractConnectionHook)
            (java.util.concurrent TimeUnit)))
@@ -9,7 +10,7 @@
   "Converts a db-spec with :host :port :dbname and :user to bonecp pool config"
   [{:keys [dbtype host port dbname user password]}]
   (let [host-part (when host (if port (format "%s:%s" host port) host))
-        pool-conf {:jdbcUrl (format "jdbc:%s://%s/%s" dbtype (or host-part "") dbname)
+        pool-conf {:jdbc-url (format "jdbc:%s://%s/%s" dbtype (or host-part "") dbname)
                    :username user}]
     (if password
       (assoc pool-conf :password password)
@@ -18,7 +19,7 @@
 (defn pooled-db
   [spec opts]
   (let [config (merge (db-spec->pool-config spec) opts)]
-    {:datasource (data/to-java BoneCPDataSource config)}))
+    {:datasource (hikari/make-datasource config)}))
 
 (defn close-pooled-db!
   [{:keys [datasource]}]


### PR DESCRIPTION
This request:

* Removes BoneCP and incorporates Hikari which is the recommended pooling library these days.
* Updates several out of date deps.
* Adds a deps.edn so that people can access the library without it being published from the clj tools.