### PR TITLE
Enable the passing of pool configuration to `pool`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ parameters in the environment. E.g.:
 (jdbc/query db2 ["SELECT 'test'"])
 ```
 
+You can pass
+[hikari-specific](https://github.com/tomekw/hikari-cp#configuration-options)
+options via the `hikari` keyword:
+
+```clj
+(def db2 (pg/pool :host "db1.example.com"
+                  :user "myaccount"
+                  :dbname "anotherdb"
+                  :password "foobar"
+                  :hikari {:read-only true))
+```
+
 The pool can be closed with:
 
 ```clj

--- a/src/clj_postgresql/pool.clj
+++ b/src/clj_postgresql/pool.clj
@@ -5,14 +5,16 @@
   (:import (java.util.concurrent TimeUnit)))
 
 (defn db-spec->pool-config
-  "Converts a db-spec with :host :port :dbname and :user to Hikari pool config"
-  [{:keys [dbtype host port dbname user password]}]
-  (let [host-part (when host (if port (format "%s:%s" host port) host))
-        pool-conf {:jdbc-url (format "jdbc:%s://%s/%s" dbtype (or host-part "") dbname)
-                   :username user}]
-    (if password
-      (assoc pool-conf :password password)
-      pool-conf)))
+  "Converts a db-spec with :host :port :dbname and :user to Hikari pool
+  config. Hikari options can be passed with `hikari`. See
+  https://github.com/tomekw/hikari-cp#configuration-options for that
+  list."
+  [{:keys [dbtype host port dbname user password hikari]}]
+  (let [host-part (when host (if port (format "%s:%s" host port) host))]
+    (cond-> {:jdbc-url (format "jdbc:%s://%s/%s" dbtype (or host-part "") dbname)
+             :username user}
+      hikari (merge hikari)
+      password (assoc :password password))))
 
 (defn pooled-db
   [spec opts]

--- a/test/clj_postgresql/t_pool.clj
+++ b/test/clj_postgresql/t_pool.clj
@@ -1,0 +1,21 @@
+(ns clj-postgresql.t-pool
+  (:use midje.sweet)
+  (:require [clj-postgresql.core :as pg]
+            [clojure.java.jdbc :as jdbc]))
+
+(defn query
+  [& args]
+  (jdbc/query (pg/pool) args))
+
+(defn query1
+  [& args]
+  (let [result (apply query args)]
+    (first result)))
+
+(fact "Pool query works"
+      (jdbc/execute! (pg/pool) "CREATE TEMPORARY TABLE bob(id text)") => [0]
+      (query1 "SELECT true AS x") => {:x true}
+      (try
+        (jdbc/execute! (pg/pool :hikari {:read-only true}) "CREATE TEMPORARY TABLE bob(id text)")
+        (catch org.postgresql.util.PSQLException e
+          (.getMessage e))) => "ERROR: cannot execute CREATE TABLE in a read-only transaction")


### PR DESCRIPTION
Allows the below options to be passed:

https://github.com/tomekw/hikari-cp#configuration-options