### PR TITLE
Update deps.edn to avoid "DEPRECATED: Libs must be qualified" messages

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,10 @@
 {:deps
  {org.clojure/clojure #:mvn{:version "1.10.0"},
-  hikari-cp #:mvn{:version "2.7.1"},
+  hikari-cp/hikari-cp #:mvn{:version "2.7.1"},
   net.postgis/postgis-jdbc #:mvn{:version "2.3.0"},
-  clj-time #:mvn{:version "0.15.1"},
+  clj-time/clj-time #:mvn{:version "0.15.1"},
   org.postgresql/postgresql #:mvn{:version "42.2.5"},
-  cheshire #:mvn{:version "5.8.1"},
+  cheshire/cheshire #:mvn{:version "5.8.1"},
   org.clojure/java.jdbc #:mvn{:version "0.7.9"},
   prismatic/schema #:mvn{:version "1.1.10"},
   org.clojure/java.data #:mvn{:version "0.1.1"}}}


### PR DESCRIPTION
```
DEPRECATED: Libs must be qualified, change hikari-cp => hikari-cp/hikari-cp
DEPRECATED: Libs must be qualified, change clj-time => clj-time/clj-time
DEPRECATED: Libs must be qualified, change cheshire => cheshire/cheshire
```